### PR TITLE
Fix issue with polyfilled array prototype functions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "angular-xmlrpc",
     "description": "AngularJS module for XML-RPC communication",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "xmlrpc.js",
     "moduleType":"globals",
     "license":"Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-xmlrpc",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "AngularJS module for XML-RPC communication",
     "main": "xmlrpc.js",
     "scripts": {

--- a/xmlrpc.js
+++ b/xmlrpc.js
@@ -480,7 +480,7 @@ angular.module('xml-rpc', [])
             children.shift(); //shift doc
             children.shift(); //shift nodeName
         }
-        if (typeof children == 'array') {
+        if (Array.isArray(children)) {
             angular.forEach(children, appendChild);
         } else if (children) {
             appendChild(children);


### PR DESCRIPTION
1. `typeof children == 'array'` is always false, since there is no type array (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof)

2. Some sites using ES polyfills like Array.remove() and in some use cases children is an array, but it is passed to appendChild, where for-in look also loops over polyfilled props -> error